### PR TITLE
Implementar caché TTL

### DIFF
--- a/app/src/main/java/edu/iesam/bikerly/app/di/LocalModule.kt
+++ b/app/src/main/java/edu/iesam/bikerly/app/di/LocalModule.kt
@@ -8,6 +8,8 @@ import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 
+const val LOCAL_TIME_CACHE = 5 * 60000
+
 @Module
 @ComponentScan("edu.iesam.bikerly")
 class LocalModule {

--- a/app/src/main/java/edu/iesam/bikerly/app/di/RemoteModule.kt
+++ b/app/src/main/java/edu/iesam/bikerly/app/di/RemoteModule.kt
@@ -5,6 +5,9 @@ import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 
+//const val REMOTE_TIME_CACHE = 1 * 86400000
+const val REMOTE_TIME_CACHE = 1 * 60000
+
 @Module
 @ComponentScan("edu.iesam.bikerly")
 class RemoteModule {

--- a/app/src/main/java/edu/iesam/bikerly/app/di/RemoteModule.kt
+++ b/app/src/main/java/edu/iesam/bikerly/app/di/RemoteModule.kt
@@ -5,8 +5,7 @@ import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 
-//const val REMOTE_TIME_CACHE = 1 * 86400000
-const val REMOTE_TIME_CACHE = 1 * 60000
+const val REMOTE_TIME_CACHE = 1 * 86400000
 
 @Module
 @ComponentScan("edu.iesam.bikerly")

--- a/app/src/main/java/edu/iesam/bikerly/data/MotorbikeDataRepository.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/MotorbikeDataRepository.kt
@@ -5,6 +5,7 @@ import edu.iesam.bikerly.data.local.mock.MotorbikeMockLocalDataSource
 import edu.iesam.bikerly.data.local.room.MotorbikeDbLocalDataSource
 import edu.iesam.bikerly.data.remote.MotorbikeFirebaseRemoteDataSource
 import edu.iesam.bikerly.data.remote.api.MotorbikeApiRemoteDataSource
+import edu.iesam.bikerly.data.remote.toModel
 import edu.iesam.bikerly.domain.Motorbike
 import edu.iesam.bikerly.domain.MotorbikeRepository
 import org.koin.core.annotation.Single
@@ -25,7 +26,7 @@ class MotorbikeDataRepository(
         } else {
             val remoteMotorbikes = getRemoteMotorbikeList()
 
-            remoteMotorbikes.onSuccess { motorbikeList ->
+            return remoteMotorbikes.onSuccess { motorbikeList ->
                 roomLocal.saveMotorbikeList(motorbikeList)
                 Result.success(remoteMotorbikes)
             }
@@ -36,25 +37,26 @@ class MotorbikeDataRepository(
     }
 
     private suspend fun getRemoteMotorbikeList(): Result<List<Motorbike>> {
-        val firebaseRemoteData = firebaseRemote.getMotorbikeList()
+        val firebaseList = firebaseRemote.getMotorbikeList().getOrNull()
+        val apiList = apiRemote.getMotorbikeList().getOrNull()
 
-        return if (firebaseRemoteData.isSuccess) {
-            firebaseRemoteData
-        } else {
-            val apiRemoteData = apiRemote.getMotorbikeList()
-
-            if (apiRemoteData.isSuccess) {
-                val motorbikeList = apiRemoteData.getOrNull()
-
-                if (motorbikeList != null) {
-                    firebaseRemote.setMotorbikeList(motorbikeList)
-                    apiRemoteData
+        return if (firebaseList != null) {
+            if (firebaseRemote.isCacheValid(firebaseList)) {
+                Result.success(firebaseList.map { it.toModel() })
+            } else {
+                if (apiList != null) {
+                    if (firebaseList.size == apiList.size) {
+                        Result.success(firebaseList.map { it.toModel() })
+                    } else {
+                        firebaseRemote.setMotorbikeList(apiList)
+                        Result.success(apiList)
+                    }
                 } else {
                     Result.failure(ErrorApp.DataError)
                 }
-            } else {
-                Result.failure(ErrorApp.DataError)
             }
+        } else {
+            Result.failure(ErrorApp.DataError)
         }
     }
 

--- a/app/src/main/java/edu/iesam/bikerly/data/MotorbikeDataRepository.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/MotorbikeDataRepository.kt
@@ -20,19 +20,19 @@ class MotorbikeDataRepository(
     override suspend fun getMotorbikeList(): Result<List<Motorbike>> {
         val localMotorbikes = roomLocal.getMotorbikeList()
 
-        return if (localMotorbikes.isSuccess) {
+        /*return if (localMotorbikes.isSuccess) {
             localMotorbikes
-        } else {
+        } else {*/
             val remoteMotorbikes = getRemoteMotorbikeList()
 
-            remoteMotorbikes.onSuccess { motorbikeList ->
+        return remoteMotorbikes.onSuccess { motorbikeList ->
                 roomLocal.saveMotorbikeList(motorbikeList)
                 Result.success(remoteMotorbikes)
             }
             remoteMotorbikes.onFailure {
                 Result.failure<ErrorApp>(ErrorApp.DataError)
             }
-        }
+        /*}*/
     }
 
     private suspend fun getRemoteMotorbikeList(): Result<List<Motorbike>> {

--- a/app/src/main/java/edu/iesam/bikerly/data/MotorbikeDataRepository.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/MotorbikeDataRepository.kt
@@ -20,19 +20,19 @@ class MotorbikeDataRepository(
     override suspend fun getMotorbikeList(): Result<List<Motorbike>> {
         val localMotorbikes = roomLocal.getMotorbikeList()
 
-        /*return if (localMotorbikes.isSuccess) {
+        return if (localMotorbikes.isSuccess) {
             localMotorbikes
-        } else {*/
+        } else {
             val remoteMotorbikes = getRemoteMotorbikeList()
 
-        return remoteMotorbikes.onSuccess { motorbikeList ->
+            remoteMotorbikes.onSuccess { motorbikeList ->
                 roomLocal.saveMotorbikeList(motorbikeList)
                 Result.success(remoteMotorbikes)
             }
             remoteMotorbikes.onFailure {
                 Result.failure<ErrorApp>(ErrorApp.DataError)
             }
-        /*}*/
+        }
     }
 
     private suspend fun getRemoteMotorbikeList(): Result<List<Motorbike>> {

--- a/app/src/main/java/edu/iesam/bikerly/data/local/room/Mappers.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/local/room/Mappers.kt
@@ -15,7 +15,7 @@ fun MotorbikeEntity.toModel(): Motorbike {
     )
 }
 
-fun Motorbike.toEntity(): MotorbikeEntity {
+fun Motorbike.toEntity(ms: Long): MotorbikeEntity {
     return MotorbikeEntity(
         this.id,
         this.make,
@@ -23,6 +23,7 @@ fun Motorbike.toEntity(): MotorbikeEntity {
         this.year,
         this.type,
         this.displacement,
-        this.img.toString()
+        this.img.toString(),
+        ms
     )
 }

--- a/app/src/main/java/edu/iesam/bikerly/data/local/room/MotorbikeDbLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/local/room/MotorbikeDbLocalDataSource.kt
@@ -1,5 +1,6 @@
 package edu.iesam.bikerly.data.local.room
 
+import edu.iesam.bikerly.app.di.LOCAL_TIME_CACHE
 import edu.iesam.bikerly.app.domain.ErrorApp
 import edu.iesam.bikerly.domain.Motorbike
 import org.koin.core.annotation.Single
@@ -8,21 +9,28 @@ import org.koin.core.annotation.Single
 class MotorbikeDbLocalDataSource(private val motorbikeDao: MotorbikeDao) {
 
     fun getMotorbikeList(): Result<List<Motorbike>> {
-        val motorbikeList = motorbikeDao.getAll()
-            .map { motorbike ->
-                motorbike.toModel()
-            }
-            .sortedByDescending { it.id }
+        val motorbikeEntityList = motorbikeDao.getAll()
 
-        return if (motorbikeList.isNotEmpty()) {
-            Result.success(motorbikeList)
+        return if (motorbikeEntityList.isNotEmpty()) {
+            if (motorbikeEntityList[0].createdAt.plus(LOCAL_TIME_CACHE) > System.currentTimeMillis()) {
+                val motorbikeList = motorbikeEntityList.map { motorbike ->
+                    motorbike.toModel()
+                }.sortedByDescending { motorbike ->
+                    motorbike.id
+                }
+                Result.success(motorbikeList)
+            } else {
+                Result.failure(ErrorApp.DataError)
+            }
         } else {
             Result.failure(ErrorApp.DataError)
         }
     }
 
     fun saveMotorbikeList(motorbikeList: List<Motorbike>) {
-        motorbikeDao.saveAll(*motorbikeList.map { it.toEntity() }.toTypedArray())
+        val ms = System.currentTimeMillis()
+
+        motorbikeDao.saveAll(*motorbikeList.map { it.toEntity(ms) }.toTypedArray())
     }
 
     fun getMotorbikeById(motorbikeId: Int): Result<Motorbike> {

--- a/app/src/main/java/edu/iesam/bikerly/data/local/room/MotorbikeEntity.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/local/room/MotorbikeEntity.kt
@@ -12,5 +12,6 @@ data class MotorbikeEntity(
     @ColumnInfo(name = "year") val year: String,
     @ColumnInfo(name = "type") val type: String,
     @ColumnInfo(name = "displacement") val displacement: String,
-    @ColumnInfo(name = "img") val img: String
+    @ColumnInfo(name = "img") val img: String,
+    @ColumnInfo(name = "created_at") val createdAt: Long
 )

--- a/app/src/main/java/edu/iesam/bikerly/data/remote/Mappers.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/remote/Mappers.kt
@@ -14,3 +14,16 @@ fun MotorbikeRemoteModel.toModel(): Motorbike {
         this.img.toUri()
     )
 }
+
+fun Motorbike.toRemoteModel(ms: Long): MotorbikeRemoteModel {
+    return MotorbikeRemoteModel(
+        this.id,
+        this.make,
+        this.model,
+        this.year,
+        this.type,
+        this.displacement,
+        this.img.toString(),
+        ms
+    )
+}

--- a/app/src/main/java/edu/iesam/bikerly/data/remote/MotorbikeFirebaseRemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/remote/MotorbikeFirebaseRemoteDataSource.kt
@@ -2,6 +2,7 @@ package edu.iesam.bikerly.data.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
+import edu.iesam.bikerly.app.di.REMOTE_TIME_CACHE
 import edu.iesam.bikerly.app.domain.ErrorApp
 import edu.iesam.bikerly.domain.Motorbike
 import kotlinx.coroutines.tasks.await
@@ -10,8 +11,14 @@ import org.koin.core.annotation.Single
 @Single
 class MotorbikeFirebaseRemoteDataSource(private val firestore: FirebaseFirestore) {
 
-    suspend fun setMotorbikeList(motorbikeList: List<Motorbike>) {
+    suspend fun setMotorbikeList(motorbikeApiList: List<Motorbike>) {
+        val ms = System.currentTimeMillis()
+
         deleteMotorbikeList()
+
+        val motorbikeList = motorbikeApiList.map { motorbike ->
+            motorbike.toRemoteModel(ms)
+        }
 
         motorbikeList.forEach { motorbike ->
             firestore.collection("motorbikes")
@@ -29,17 +36,24 @@ class MotorbikeFirebaseRemoteDataSource(private val firestore: FirebaseFirestore
     }
 
     suspend fun getMotorbikeList(): Result<List<Motorbike>> {
-        val motorbikeList =
+        val motorbikeFirebaseList =
             firestore.collection("motorbikes")
                 .orderBy("id", Query.Direction.DESCENDING)
                 .get()
                 .await()
                 .map {
-                    it.toObject(MotorbikeRemoteModel::class.java).toModel()
+                    it.toObject(MotorbikeRemoteModel::class.java)
                 }
 
-        return if (motorbikeList.isNotEmpty()) {
-            Result.success(motorbikeList)
+        return if (motorbikeFirebaseList.isNotEmpty()) {
+            if (motorbikeFirebaseList[0].createdAt.plus(REMOTE_TIME_CACHE) > System.currentTimeMillis()) {
+                val motorbikeList = motorbikeFirebaseList.map { motorbike ->
+                    motorbike.toModel()
+                }
+                Result.success(motorbikeList)
+            } else {
+                Result.failure(ErrorApp.DataError)
+            }
         } else {
             Result.failure(ErrorApp.DataError)
         }

--- a/app/src/main/java/edu/iesam/bikerly/data/remote/MotorbikeFirebaseRemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/remote/MotorbikeFirebaseRemoteDataSource.kt
@@ -35,7 +35,7 @@ class MotorbikeFirebaseRemoteDataSource(private val firestore: FirebaseFirestore
         }
     }
 
-    suspend fun getMotorbikeList(): Result<List<Motorbike>> {
+    suspend fun getMotorbikeList(): Result<List<MotorbikeRemoteModel>> {
         val motorbikeFirebaseList =
             firestore.collection("motorbikes")
                 .orderBy("id", Query.Direction.DESCENDING)
@@ -46,17 +46,14 @@ class MotorbikeFirebaseRemoteDataSource(private val firestore: FirebaseFirestore
                 }
 
         return if (motorbikeFirebaseList.isNotEmpty()) {
-            if (motorbikeFirebaseList[0].createdAt.plus(REMOTE_TIME_CACHE) > System.currentTimeMillis()) {
-                val motorbikeList = motorbikeFirebaseList.map { motorbike ->
-                    motorbike.toModel()
-                }
-                Result.success(motorbikeList)
-            } else {
-                Result.failure(ErrorApp.DataError)
-            }
+            Result.success(motorbikeFirebaseList)
         } else {
             Result.failure(ErrorApp.DataError)
         }
+    }
+
+    fun isCacheValid(motorbikeList: List<MotorbikeRemoteModel>): Boolean {
+        return motorbikeList.first().createdAt.plus(REMOTE_TIME_CACHE) > System.currentTimeMillis()
     }
 
     suspend fun getMotorbikeById(motorbikeId: Int): Result<Motorbike> {

--- a/app/src/main/java/edu/iesam/bikerly/data/remote/MotorbikeRemoteModel.kt
+++ b/app/src/main/java/edu/iesam/bikerly/data/remote/MotorbikeRemoteModel.kt
@@ -11,5 +11,6 @@ data class MotorbikeRemoteModel(
     @SerializedName("year") val year: String = "",
     @SerializedName("type") val type: String = "",
     @SerializedName("displacement") val displacement: String = "",
-    @SerializedName("img") val img: String = ""
+    @SerializedName("img") val img: String = "",
+    @SerializedName("created_at") val createdAt: Long = 0
 )


### PR DESCRIPTION
## 🤔 Descripción del problema a resolver

Se pide implementar una caché TTL que al pasar 5 minutos se vuelvan a pedir los datos de remoto y actualice los datos en local.

## 💡 Proceso seguido para resolver el problema.

Se crea una constante que guarde el tiempo que durará la caché, en nuestro caso 5 minutos (300.000 ms).

Se crea un nuevo atributo en la clase Motorbike llamado created_at para guardar los milisegundos que indicarán el momento en el que se haya guardado en local dicha moto.

Se modifica la función de guardar en local para que se pasen los milisegundos del momento en el que se guardan dichos datos y se pasan mediante la entidad.

También se realiza la gestión de datos en la función donde se obtiene el listado de motos para que se realice una nueva comprobación, esta comprobará si los datos están caducados o no para saber si los tiene que obtener de remoto o de local.

## 👩‍💻 Resumen de los cambios introducidos

Se crea una nueva constante con el tiempo de caché, además de crear un nuevo atributo que guardará el tiempo en el que se guardan los datos en local y se realiza la comprobación para ver si los datos están caducados.

## ✋ Notas adicionales (Disclaimer)

También se implementa una caché remota que durará un día (86.400.000 ms) para que se actualicen los datos de la api a Firebase por si se ha añadido alguna moto nueva o ha habido algún cambio en alguna de ellas.